### PR TITLE
adds exception handing for npm3 flat dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var path = require('path');
+var fs = require('fs');
 var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
@@ -9,6 +10,14 @@ module.exports = {
 
   treeForAddon: function(tree) {
     var lodashPath = path.join(this.project.addonPackages['ember-lodash'].path, 'node_modules', 'lodash-es');
+
+    // support npm v3 flat dependencies
+    try {
+      fs.accessSync(lodashPath);
+    } catch (error) {
+      lodashPath = path.join('node_modules', 'lodash-es');
+    }
+
     var lodashTree = this.treeGenerator(lodashPath);
 
     var trees = mergeTrees([lodashTree, tree], {


### PR DESCRIPTION
Addresses #5 by trying to access the lodash-es path as nested ember-lodash module path and falling back to a npm3 flat hierarchy path in case of an exception.