### PR TITLE
Fix relative lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
   name: 'lodash',
 
   treeForAddon: function(tree) {
-    var lodashPath = path.join(this.project.addonPackages['ember-lodash'].path, 'node_modules', 'lodash-es');
+    var lodashPath = path.dirname(require.resolve('lodash-es/lodash.js'));
     var lodashTree = this.treeGenerator(lodashPath);
 
     var trees = mergeTrees([lodashTree, tree], {


### PR DESCRIPTION
This make ember-lodash usable as the dependency of a dependency. Closes #4.