### PR TITLE
Workaround for ember 2.12 beta issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ var Funnel = require('broccoli-funnel');
 module.exports = {
   name: 'lodash',
 
+  _shouldCompileJS: function() {
+    return true;
+  },
+
   treeForAddon: function(tree) {
     var lodashPath = path.dirname(require.resolve('lodash-es'));
 


### PR DESCRIPTION
Closes: #89 

Ember 2.12 beta 1 skips js preprocess unless addon has .js files, see ember-cli/ember-cli#6530, 

https://github.com/ember-cli/ember-cli/pull/6530/files#diff-f1e1923c0440a385f51d2a81c0e53b64R941

