### PR TITLE
Use _super.methodName instead of bare super.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,6 @@ module.exports = {
       tree = lodashTree;
     }
 
-    return this._super(tree);
+    return this._super.treeForAddon.call(this, tree);
   }
 };


### PR DESCRIPTION
Older versions of ember-cli do not support invoking _super as an argument (yet all versions that I am aware of support this syntax).