### PR TITLE
Update to ember-cli-babel v6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-string-replace": "^0.1.1",
-    "ember-cli-babel": "6.0.0-beta.9",
+    "ember-cli-babel": "6.1.0",
     "lodash-es": "^4.17.4"
   },
   "ember-addon": {


### PR DESCRIPTION
Have not tested it locally yet, but I hope this will solve some issues we are having when upgrading to latest Ember CLI and babel. 