### PR TITLE
Fix lodash replacement regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = {
     lodashTree = replace(lodashTree, {
       files: [ '_defineProperty.js' ],
       pattern: {
-        match: /catch(e) { }/g,
+        match: /catch ?\(e\) ?{ ?}/g,
         replacement: 'catch(e) { return null; }'
       }
     });


### PR DESCRIPTION
#104 did not work for me, the `defineProperty` replacement was not applied, as could be seen by the `broccoli-debug` output. The regex seems to not match https://github.com/lodash/lodash/blob/es/_defineProperty.js#L8 regarding white spaces.

cc @rwjblue 