### PR TITLE
Update ember-cli-babel to the latest version for node.js 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-string-replace": "^0.1.1",
-    "ember-cli-babel": "6.1.0",
+    "ember-cli-babel": "^6.4.1",
     "lodash-es": "^4.17.4"
   },
   "ember-addon": {


### PR DESCRIPTION
Also specify the version using a version range.

This upgrade makes it node.js 8 compatible.

Otherwise this error appears:
``error ember-cli-babel@6.1.0: The engine "node" is incompatible with this module. Expected version "^4.5 || 6.* || 7.*".``